### PR TITLE
Add support for directory and file detection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,37 +1,108 @@
 // Dependencies
 var Fs = require("fs");
 
-/**
- * IsThere
- * Checks if a file or directory exists on given path.
- *
- * @name IsThere
- * @function
- * @param {String} path The path to the file or directory.
- * @param {Function} callback The callback function called with a boolean value
- * representing if the file or directory exists. If this parameter is not a
- * function, the function will run the synchronously and return the value.
- * @return {IsThere|Boolean} The `IsThere` function if the `callback` parameter
- * was provided, otherwise a boolean value indicating if the file/directory
- * exists or not.
- */
-function IsThere(path, callback) {
+var IsThere = (function() {
+  /**
+   * IsThere
+   * Checks if a file or directory exists on given path.
+   * Use without the new keyword.
+   *
+   * @class IsThere
+   * @param {String} path The path to the file or directory.
+   * @param {Function} callback The callback function called with a boolean value
+   * representing if the file or directory exists. If this parameter is not a
+   * function, the function will run synchronously and return the value.
+   * @return {IsThere|Boolean} The `IsThere` function if the `callback` parameter
+   * was provided, otherwise a boolean value indicating if the file/directory
+   * exists or not.
+   */
 
-    // Async
-    if (typeof callback === "function") {
-        Fs.stat(path, function (err) {
-            callback(!err);
-        });
-        return IsThere;
-    }
+  var IsThere = function(path, callback) {
+      // Async
+      if (typeof callback === "function") {
+          Fs.stat(path, function (err) {
+              callback(!err);
+          });
+          return IsThere;
+      }
 
-    // Sync
-    try {
-        Fs.statSync(path);
-        return true;
-    } catch (err) {
-        return false;
-    };
-}
+      // Sync
+      try {
+          Fs.statSync(path);
+          return true;
+      } catch (err) {
+          return false;
+      };
+  }
+  /**
+   * @function directory
+   * @memberOf IsThere
+   * @param {String} path The path to the directory.
+   * @param {Function} callback The callback function called with a boolean value
+   * representing if the directory exists. If this parameter is not a
+   * function, the function will run synchronously and return the value.
+   * @return {IsThere|Boolean} The `IsThere` function if the `callback` parameter
+   * was provided, otherwise a boolean value indicating if the directory exists or not.
+   *
+   */
+  IsThere.directory = function(path, callback) {
+      // Async
+      if (typeof callback === "function") {
+          Fs.stat(path, function (err, stats) {
+              var result = !!(stats && stats.isDirectory());
+
+              callback(result);
+          });
+          return IsThere;
+      }
+
+      // Sync
+      try {
+          if (Fs.statSync(path)) {
+              return Fs.statSync(path).isDirectory();
+          }
+      } catch (_err) {
+          return false;
+      };
+
+      return false;
+  },
+  /**
+   * @function file
+   * @memberOf IsThere
+   * @param {String} path The path to the file.
+   * @param {Function} callback The callback function called with a boolean value
+   * representing if the file exists. If this parameter is not a
+   * function, the function will run synchronously and return the value.
+   * @return {IsThere|Boolean} The `IsThere` function if the `callback` parameter
+   * was provided, otherwise a boolean value indicating if the file exists or not.
+   *
+   */
+
+  IsThere.file = function(path, callback) {
+      // Async
+      if (typeof callback === "function") {
+          Fs.stat(path, function (err, stats) {
+              var result = !!(stats && stats.isFile());
+
+              callback(result);
+          });
+          return IsThere;
+      }
+
+      // Sync
+      try {
+          if (Fs.statSync(path)) {
+              return Fs.statSync(path).isFile();
+          }
+      } catch (_err) {
+          return false;
+      };
+
+      return false;
+  }
+
+  return IsThere;
+})();
 
 module.exports = IsThere;

--- a/test/index.js
+++ b/test/index.js
@@ -1,45 +1,136 @@
-// Dependencies
 var IsThere = require("../lib")
   , Assert = require("assert")
+  , PATHS
   ;
 
-// Paths to test
-const PATHS = [
-    // exist
-    ["dir", true]
-  , ["dir/another", true]
-  , ["dir/another/file", true]
-  , ["dir/file", true]
-  , ["file", true]
-  , ["file.ext", true]
-    // don't exist
-  , ["foo", false]
-  , ["foo/bar", false]
-  , ["foo.bar", false]
-  , ["foo/bar.foo", false]
-].map(function (c) {
-    return [__dirname + "/contents/" + c[0], c[1]];
-});
-
-// Sync
-it("should check the file/directory existence synchronously", function (cb) {
-    PATHS.forEach(function (c) {
-        Assert.equal(IsThere(c[0]), c[1]);
-    });
-    cb();
-});
-
-// Async
-it("should check the file/directory existence asynchronously", function (cb) {
-    function doSeq(i) {
-        i = i || 0;
-        var cPath = PATHS[i];
-        if (!cPath) { return cb(); }
-        IsThere(cPath[0], function (exists) {
-            Assert.equal(exists, cPath[1]);
-            doSeq(i + 1);
+describe('#path', function() {
+    before(function() {
+        // Paths to test
+        PATHS = [
+            // exist
+            ["dir", true]
+          , ["dir/another", true]
+          , ["dir/another/file", true]
+          , ["dir/file", true]
+          , ["file", true]
+          , ["file.ext", true]
+            // don't exist
+          , ["foo", false]
+          , ["foo/bar", false]
+          , ["foo.bar", false]
+          , ["foo/bar.foo", false]
+        ].map(function (c) {
+            return [__dirname + "/contents/" + c[0], c[1]];
         });
-    }
-    doSeq();
+    });
+
+    // Sync
+    it("should check the file/directory existence synchronously", function (cb) {
+        PATHS.forEach(function (c) {
+            Assert.equal(IsThere(c[0]), c[1]);
+        });
+        cb();
+    });
+
+    // Async
+    it("should check the file/directory existence asynchronously", function (cb) {
+        function doSeq(i) {
+            i = i || 0;
+            var cPath = PATHS[i];
+            if (!cPath) { return cb(); }
+            IsThere(cPath[0], function (exists) {
+                Assert.equal(exists, cPath[1]);
+                doSeq(i + 1);
+            });
+        }
+        doSeq();
+    });
 });
 
+describe('#directory', function() {
+    before(function() {
+        // Paths to test
+        PATHS = [
+            // exist
+            ["dir", true]
+          , ["dir/another", true]
+          , ["dir/another/file", false]
+          , ["dir/file", false]
+          , ["file", false]
+          , ["file.ext", false]
+            // don't exist
+          , ["foo", false]
+          , ["foo/bar", false]
+          , ["foo.bar", false]
+          , ["foo/bar.foo", false]
+        ].map(function (c) {
+            return [__dirname + "/contents/" + c[0], c[1]];
+        });
+    });
+
+    // Sync
+    it("should check the directory existence synchronously", function (cb) {
+        PATHS.forEach(function (c) {
+            Assert.equal(IsThere.directory(c[0]), c[1]);
+        });
+        cb();
+    });
+
+    // Async
+    it("should check the directory existence asynchronously", function (cb) {
+        function doSeq(i) {
+            i = i || 0;
+            var cPath = PATHS[i];
+            if (!cPath) { return cb(); }
+            IsThere.directory(cPath[0], function (exists) {
+                Assert.equal(exists, cPath[1]);
+                doSeq(i + 1);
+            });
+        }
+        doSeq();
+    });
+});
+
+describe('#file', function() {
+    before(function() {
+        // Paths to test
+        PATHS = [
+            // exist
+            ["dir", false]
+          , ["dir/another", false]
+          , ["dir/another/file", true]
+          , ["dir/file", true]
+          , ["file", true]
+          , ["file.ext", true]
+            // don't exist
+          , ["foo", false]
+          , ["foo/bar", false]
+          , ["foo.bar", false]
+          , ["foo/bar.foo", false]
+        ].map(function (c) {
+            return [__dirname + "/contents/" + c[0], c[1]];
+        });
+    });
+
+    // Sync
+    it("should check the file existence synchronously", function (cb) {
+        PATHS.forEach(function (c) {
+            Assert.equal(IsThere.file(c[0]), c[1]);
+        });
+        cb();
+    });
+
+    // Async
+    it("should check the file existence asynchronously", function (cb) {
+        function doSeq(i) {
+            i = i || 0;
+            var cPath = PATHS[i];
+            if (!cPath) { return cb(); }
+            IsThere.file(cPath[0], function (exists) {
+                Assert.equal(exists, cPath[1]);
+                doSeq(i + 1);
+            });
+        }
+        doSeq();
+    });
+});


### PR DESCRIPTION
Hey @IonicaBizau, this PR adds `directory()` and `file()` to check if they exist.

I nested existing functionality under `path()`, so now it has the following three methods:

`directory()`
`file()`
`path()`

It is a breaking change, and you would probably want to bump the major version. Once reviewed, happy to make appropriate changes to README. Thanks!

Closes #19